### PR TITLE
Use locale command instead of date

### DIFF
--- a/current-locale.cabal
+++ b/current-locale.cabal
@@ -2,7 +2,7 @@ name: current-locale
 version: 0.1.0.1
 synopsis: Get the current system locale in System.Locale format
 description:
-  Use the system 'date' command to find out the current
+  Use the system 'locale' command to find out the current
   system locale in System.Locale format.
 homepage: https://github.com/koterpillar/current-locale
 license: MIT
@@ -14,7 +14,8 @@ build-type: Simple
 cabal-version: >=1.8
 library
   exposed-modules: System.CurrentLocale
-  build-depends: old-locale >= 1.0, process >= 1.0.1.1, base > 3 && < 5
+  build-depends: old-locale >= 1.0, process >= 1.0.1.1, base > 3 && < 5, split
+  ghc-options: -Wall -fwarn-tabs
 source-repository head
   type: git
   location: git://github.com/koterpillar/current-locale.git


### PR DESCRIPTION
Using locale allows to retrieve more information than date: the time
formats can also be populated. It also reads all the data by running one
command.
